### PR TITLE
Added world generator settings and other tweaks

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -2,8 +2,8 @@
 #Wed Jul 29 11:49:36 EDT 2015
 spawn-protection=16
 max-tick-time=60000
-generator-settings=
-force-gamemode=false
+generator-settings={"seaLevel":63,"heightScale":684.412,"lowerLimitScale":512,"upperLimitScale":512,"depthNoiseScaleX":200,"depthNoiseScaleZ":200,"depthNoiseScaleExponent":0.5,"mainNoiseScaleX":80,"mainNoiseScaleY":160,"mainNoiseScaleZ":80,"baseSize":8.5,"stretchY":12,"biomeDepthWeight":1,"biomeDepthOffset":0,"biomeScaleWeight":1,"biomeScaleOffset":0,"useCaves":true,"useDungeons":true,"dungeonChance":100,"useStrongholds":true,"useVillages":true,"useMineShafts":true,"useTemples":true,"useRavines":true,"useWaterLakes":true,"waterLakeChance":4,"useLavaLakes":true,"lavaLakeChance":80,"useLavaOceans":false,"fixedBiome":-1,"biomeSize":4,"riverSize":4,"dirtSize":33,"dirtCount":10,"dirtMinHeight":0,"dirtMaxHeight":256,"gravelSize":33,"gravelCount":8,"gravelMinHeight":0,"gravelMaxHeight":256,"graniteSize":33,"graniteCount":10,"graniteMinHeight":0,"graniteMaxHeight":80,"dioriteSize":33,"dioriteCount":10,"dioriteMinHeight":0,"dioriteMaxHeight":80,"andesiteSize":33,"andesiteCount":10,"andesiteMinHeight":0,"andesiteMaxHeight":80,"coalSize":17,"coalCount":20,"coalMinHeight":0,"coalMaxHeight":128,"ironSize":9,"ironCount":20,"ironMinHeight":0,"ironMaxHeight":64,"goldSize":9,"goldCount":10,"goldMinHeight":0,"goldMaxHeight":32,"redstoneSize":8,"redstoneCount":10,"redstoneMinHeight":0,"redstoneMaxHeight":16,"diamondSize":8,"diamondCount":10,"diamondMinHeight":0,"diamondMaxHeight":16,"lapisSize":7,"lapisCount":10,"lapisCenterHeight":16,"lapisSpread":16,"coordinateScale":684.412}
+force-gamemode=true
 allow-nether=true
 gamemode=0
 enable-query=false
@@ -15,7 +15,7 @@ resource-pack-hash=
 announce-player-achievements=true
 pvp=false
 snooper-enabled=false
-level-type=DEFAULT
+level-type=CUSTOMIZED
 hardcore=false
 enable-command-block=true
 max-players=10


### PR DESCRIPTION
Couple of nice things to consider:

1.  The world generator settings will place a little more of the rare ores.  All rare ores now spawn as frequently as redstone.  Iron/coal unchanged.
2.  force-gamemode allows you to "/gamemode 1 YourUserName" to switch someone into Creative mode (or 0 back for Survival)
